### PR TITLE
Remove google verification file

### DIFF
--- a/google81b31c209803ef96.html
+++ b/google81b31c209803ef96.html
@@ -1,1 +1,0 @@
-google-site-verification: google81b31c209803ef96.html


### PR DESCRIPTION
The file has been out of date after moving the site to the new indietasten.net hostname anyways. Also, I no longer need this domain to be verified by Google anymore, as I don't plan to use any products on the page.

Closes #119